### PR TITLE
fix: fix implementation of the mzAcquisitionRange metric

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: MsQuality
 Type: Package
 Title: MsQuality - Quality metric calculation from Spectra and MsExperiment objects
-Version: 1.1.1
+Version: 1.1.2
 Date: 2023-07-13
 Authors@R: c(person(given = "Thomas", family = "Naake", 
 		email = "thomasnaake@googlemail.com", role = c("aut", "cre"),

--- a/R/function_Spectra_metrics.R
+++ b/R/function_Spectra_metrics.R
@@ -661,8 +661,8 @@ numberSpectra <- function(spectra, msLevel = 1L, ...) {
 #' 
 #' The metric is calculated as follows: \cr
 #' (1) the \code{Spectra} object is filtered according to the MS level, \cr 
-#' (2) the m/z values of the peaks within the \code{Spectra} object are obtained, \cr 
-#' (3) the minimum and maximum m/z values are obtained and returned. 
+#' (2) the precursor m/z values of the peaks within the \code{Spectra} object are obtained, \cr 
+#' (3) the minimum and maximum precursor m/z values are obtained and returned. 
 #'
 #' @details
 #' MS:4000069 \cr
@@ -693,7 +693,8 @@ numberSpectra <- function(spectra, msLevel = 1L, ...) {
 #'     msLevel = c(2L, 2L, 2L),
 #'     polarity = c(1L, 1L, 1L),
 #'     id = c("HMDB0000001", "HMDB0000001", "HMDB0001847"),
-#'     name = c("1-Methylhistidine", "1-Methylhistidine", "Caffeine"))
+#'     name = c("1-Methylhistidine", "1-Methylhistidine", "Caffeine"),
+#'     precursorMz = c(170.16, 170.16, 195.08))
 #' ## Assign m/z and intensity values
 #' spd$mz <- list(
 #'     c(109.2, 124.2, 124.5, 170.16, 170.52),
@@ -706,14 +707,14 @@ numberSpectra <- function(spectra, msLevel = 1L, ...) {
 #'     c(0.459, 2.585, 2.446, 0.508, 8.968, 0.524, 0.974, 100.0, 40.994))
 #' sps <- Spectra(spd)
 #' mzAcquisitionRange(spectra = sps, msLevel = 2L)
-mzAcquisitionRange <- function(spectra, msLevel = 1L, ...) {
+mzAcquisitionRange <- function(spectra, msLevel = 2L, ...) {
     
     spectra <- filterMsLevel(object = spectra, msLevel)
     
     if (length(spectra) == 0) {
         res <- c(NaN, NaN)
     } else {
-        mzList <- mz(spectra)
+        mzList <- precursorMz(spectra)
         mz <- unlist(mzList)
         res <- range(mz)
     }

--- a/inst/NEWS.md
+++ b/inst/NEWS.md
@@ -1,3 +1,7 @@
+# MsQuality 1.1.2
+
+- Fix implementation of `mzAquisitionRange`.
+
 # MsQuality 0.99
 
 ## Changes in version 0.99.9 (2023-04-18)

--- a/man/mzAcquisitionRange.Rd
+++ b/man/mzAcquisitionRange.Rd
@@ -4,7 +4,7 @@
 \alias{mzAcquisitionRange}
 \title{m/z acquisition range (MS:4000069)}
 \usage{
-mzAcquisitionRange(spectra, msLevel = 1L, ...)
+mzAcquisitionRange(spectra, msLevel = 2L, ...)
 }
 \arguments{
 \item{spectra}{\code{Spectra} object}
@@ -23,8 +23,8 @@ recorded." [PSI:MS] \cr
 
 The metric is calculated as follows: \cr
 (1) the \code{Spectra} object is filtered according to the MS level, \cr 
-(2) the m/z values of the peaks within the \code{Spectra} object are obtained, \cr 
-(3) the minimum and maximum m/z values are obtained and returned.
+(2) the precursor m/z values of the peaks within the \code{Spectra} object are obtained, \cr 
+(3) the minimum and maximum precursor m/z values are obtained and returned.
 }
 \details{
 MS:4000069 \cr
@@ -43,7 +43,8 @@ spd <- DataFrame(
     msLevel = c(2L, 2L, 2L),
     polarity = c(1L, 1L, 1L),
     id = c("HMDB0000001", "HMDB0000001", "HMDB0001847"),
-    name = c("1-Methylhistidine", "1-Methylhistidine", "Caffeine"))
+    name = c("1-Methylhistidine", "1-Methylhistidine", "Caffeine"),
+    precursorMz = c(170.16, 170.16, 195.08))
 ## Assign m/z and intensity values
 spd$mz <- list(
     c(109.2, 124.2, 124.5, 170.16, 170.52),

--- a/tests/testthat/test_function_Spectra_metrics.R
+++ b/tests/testthat/test_function_Spectra_metrics.R
@@ -169,7 +169,7 @@ test_that("mzAcquisitionRange works properly.", {
     expect_error(mzAcquisitionRange(NULL), "unable to find an inherited method")
     expect_error(mzAcquisitionRange(1:10), "unable to find an inherited method")
     tmp <- mzAcquisitionRange(sps_sciex, msLevel = 1L)
-    expect_equal(as.numeric(tmp), c(105, 134), tolerance = 1e-06)
+    expect_equal(as.numeric(tmp), range(precursorMz(sps_sciex)))
     expect_equal(names(tmp), c("min", "max"))
     tmp <- mzAcquisitionRange(sps_sciex, msLevel = 2L)
     expect_equal(as.numeric(tmp), c(NaN, NaN))


### PR DESCRIPTION
this PR changes the metric to use the precursor m/z instead of the m/z values.